### PR TITLE
[#136] Pass in full URL if one was provided

### DIFF
--- a/internal/connect/controlplane/remote/remote.go
+++ b/internal/connect/controlplane/remote/remote.go
@@ -34,7 +34,7 @@ func NewManualExecutor(namespace, name, endpoint, email, password string) (execu
 		return nil, err
 	}
 	host := fmtEndpoint.Hostname()
-	formatedEndpoint, err := util.GetControllerEndpoint(host)
+	formatedEndpoint, err := util.GetControllerEndpoint(fmtEndpoint.String())
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func NewExecutor(namespace, name string, yaml []byte, kind config.Kind) (execute
 			return nil, err
 		}
 		host := fmtEndpoint.Hostname()
-		formatedEndpoint, err := util.GetControllerEndpoint(host)
+		formatedEndpoint, err := util.GetControllerEndpoint(fmtEndpoint.String())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/get_controller_endpoint.go
+++ b/pkg/util/get_controller_endpoint.go
@@ -14,8 +14,8 @@
 package util
 
 import (
-	"net"
 	"net/url"
+	"strings"
 
 	"github.com/eclipse-iofog/iofog-go-sdk/v2/pkg/client"
 )
@@ -24,6 +24,11 @@ func GetControllerEndpoint(host string) (endpoint string, err error) {
 	// Generate controller endpoint
 	u, err := url.Parse(host)
 	if err != nil || u.Host == "" {
+
+		if !strings.Contains(host, ":") {
+			host = host + ":" + client.ControllerPortString
+		}
+
 		u, err = url.Parse("//" + host) // Try to see if controllerEndpoint is an IP, in which case it needs to be pefixed by //
 		if err != nil {
 			return "", err
@@ -31,10 +36,6 @@ func GetControllerEndpoint(host string) (endpoint string, err error) {
 	}
 	if u.Scheme == "" {
 		u.Scheme = "http"
-	}
-	_, _, err = net.SplitHostPort(u.Host) // Returns error if port is not specified
-	if err != nil {
-		u.Host = u.Host + ":" + client.ControllerPortString
 	}
 	return u.String(), nil
 }

--- a/pkg/util/get_controller_endpoint_test.go
+++ b/pkg/util/get_controller_endpoint_test.go
@@ -1,0 +1,53 @@
+/*
+ *  *******************************************************************************
+ *  * Copyright (c) 2020 Red Hat, Inc.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Eclipse Public License v. 2.0 which is available at
+ *  * http://www.eclipse.org/legal/epl-2.0
+ *  *
+ *  * SPDX-License-Identifier: EPL-2.0
+ *  *******************************************************************************
+ *
+ */
+package util
+
+import (
+	"testing"
+)
+
+func TestGetControllerEndpoint(t *testing.T) {
+
+	for _, entry := range []struct {
+		input  string
+		output string
+	}{
+		{
+			"foo-bar", "http://foo-bar:51121",
+		},
+		{
+			"https://foo-bar", "https://foo-bar",
+		},
+		{
+			"http://foo-bar", "http://foo-bar",
+		},
+		{
+			"foo-bar:1234", "http://foo-bar:1234",
+		},
+		{
+			"1.2.3.4", "http://1.2.3.4:51121",
+		},
+	} {
+
+		if result, err := GetControllerEndpoint(entry.input); result != entry.output {
+			if err != nil {
+				t.Errorf("Failed for input %v, when it should not", entry.input)
+			} else {
+				t.Errorf("Wrong result - expected: %v, actual: %v, for input: %v", entry.output, result, entry.input)
+			}
+
+		}
+
+	}
+
+}


### PR DESCRIPTION
**NOTE:** This also needs a fix for https://github.com/eclipse-iofog/iofog-go-sdk/issues/21 … otherwise the `https:` scheme and port information will be passed to the SDK, but the SDK will downgrade the connection anyway to `http`.

Signed-off-by: Jens Reimann <jreimann@redhat.com>