### PR TITLE
fix(goreleaser): inject literal project_name and fix Windows exe naming

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,13 +4,13 @@
 #   GITHUB_REPOSITORY=eclipse-iofog/iofogctl  script/goreleaser-release.sh release --clean
 version: 2
 
-project_name: "{{ .Env.CLI_BINARY_NAME }}"
+# project_name is substituted by script/goreleaser-release.sh (__CLI_BINARY_NAME__).
+# GoReleaser does not evaluate templates in project_name.
+project_name: __CLI_BINARY_NAME__
 
 env:
   - GO111MODULE=on
   - CGO_ENABLED=1
-  - FLAVOR={{ .Env.FLAVOR }}
-  - CLI_BINARY_NAME={{ .Env.CLI_BINARY_NAME }}
 
 before:
   hooks:
@@ -161,7 +161,7 @@ archives:
   - id: windows
     ids:
       - build_windows
-    name_template: "{{ .ProjectName }}_{{ .Version }}_windows_{{ .Arch }}.exe"
+    name_template: "{{ .Env.CLI_BINARY_NAME }}_{{ .Version }}_windows_{{ .Arch }}"
     formats: ['binary']
 
 checksum:

--- a/script/goreleaser-release.sh
+++ b/script/goreleaser-release.sh
@@ -5,4 +5,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 eval "$("$ROOT/script/goreleaser-env.sh")"
-exec goreleaser "$@"
+
+cfg="$(mktemp)"
+trap 'rm -f "$cfg"' EXIT
+sed "s/__CLI_BINARY_NAME__/${CLI_BINARY_NAME}/g" .goreleaser.yml >"$cfg"
+exec goreleaser -f "$cfg" "$@"


### PR DESCRIPTION
GoReleaser does not template project_name; substitute __CLI_BINARY_NAME__ in goreleaser-release.sh. Drop duplicate .exe suffix on Windows binary uploads.