### PR TITLE
fix(get): align table columns independent of terminal tab width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to potctl / iofogctl are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `get` and NATS wide tables pad with spaces so headers such as AGENT `ENGINE` align regardless of terminal tab width
+- Unprovisioned agent rows include the ENGINE column
+
 ## [v3.8.3-rc.1] — August 2026
 
 v3.8.3 release candidate. Bumps Go, SDK, operator, and component pins to the v3.8.3-rc.1 line.

--- a/internal/cmd/nats.go
+++ b/internal/cmd/nats.go
@@ -319,7 +319,7 @@ func printNatsOutput(obj interface{}, output string, wide [][]string) error {
 }
 
 func printWideTable(table [][]string) error {
-	writer := tabwriter.NewWriter(os.Stdout, 16, 8, 1, '\t', 0)
+	writer := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
 	defer writer.Flush()
 	for _, row := range table {
 		for _, col := range row {

--- a/internal/get/agents.go
+++ b/internal/get/agents.go
@@ -106,6 +106,7 @@ func tabulateAgents(agentInfos []client.AgentInfo) (table [][]string, err error)
 				agent.IPAddressExternal,
 				"-",
 				"-",
+				"-",
 			}
 			table[idx+1] = append(table[idx+1], row...)
 		} else {

--- a/internal/get/print.go
+++ b/internal/get/print.go
@@ -7,10 +7,8 @@ import (
 )
 
 func print(table [][]string) error {
-	minWidth := 16
-	tabWidth := 8
-	padding := 1
-	writer := tabwriter.NewWriter(os.Stdout, minWidth, tabWidth, padding, '\t', 0)
+	// Space padding so column alignment does not depend on the terminal tab width.
+	writer := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
 	defer writer.Flush()
 
 	for _, row := range table {


### PR DESCRIPTION
Pad get/NATS tables with spaces and include ENGINE on unprovisioned agent rows.